### PR TITLE
feat: add formatted methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,27 @@ goos: darwin
 goarch: arm64
 pkg: github.com/hugginsio/clogs
 cpu: Apple M2
-BenchmarkLogger_MessageSizes/clogs_small-8         	 8775430	       131.7 ns/op	      24 B/op	       1 allocs/op
-BenchmarkLogger_MessageSizes/standard_small-8      	 4398867	       273.1 ns/op	      24 B/op	       2 allocs/op
-BenchmarkLogger_MessageSizes/slog_small-8          	 1559587	       769.6 ns/op	       8 B/op	       0 allocs/op
-BenchmarkLogger_MessageSizes/clogs_medium-8        	 8233572	       145.6 ns/op	      24 B/op	       1 allocs/op
-BenchmarkLogger_MessageSizes/standard_medium-8     	 4181818	       287.1 ns/op	      24 B/op	       2 allocs/op
-BenchmarkLogger_MessageSizes/slog_medium-8         	  504582	      2379 ns/op	       8 B/op	       0 allocs/op
-BenchmarkLogger_MessageSizes/clogs_large-8         	 6328874	       189.1 ns/op	      24 B/op	       1 allocs/op
-BenchmarkLogger_MessageSizes/standard_large-8      	 3342482	       358.7 ns/op	      24 B/op	       1 allocs/op
-BenchmarkLogger_MessageSizes/slog_large-8          	  105213	     11391 ns/op	       8 B/op	       0 allocs/op
-PASS
-ok  	github.com/hugginsio/clogs	11.021s
+
+BenchmarkLogger_MessageSizes/clogs_small-8                  	15433291	       77.28 ns/op	      24 B/op	       1 allocs/op
+BenchmarkLogger_MessageSizes/standard_small-8               	 7812878	       153.5 ns/op	      24 B/op	       2 allocs/op
+BenchmarkLogger_MessageSizes/slog_small-8                   	 2695798	       446.3 ns/op	       8 B/op	       0 allocs/op
+
+BenchmarkLogger_MessageSizes/clogs_medium-8                 	14166360	       85.44 ns/op	      24 B/op	       1 allocs/op
+BenchmarkLogger_MessageSizes/standard_medium-8              	 7419481	       162.9 ns/op	      24 B/op	       2 allocs/op
+BenchmarkLogger_MessageSizes/slog_medium-8                   	  837007	        1435 ns/op	       8 B/op	       0 allocs/op
+
+BenchmarkLogger_MessageSizes/clogs_large-8                  	11016468	       109.2 ns/op	      24 B/op	       1 allocs/op
+BenchmarkLogger_MessageSizes/standard_large-8               	 5891317	       204.1 ns/op	      24 B/op	       2 allocs/op
+BenchmarkLogger_MessageSizes/slog_large-8                    	  171866	        7007 ns/op	       8 B/op	       0 allocs/op
+
+BenchmarkLogger_MessageFormatting/clogs_single-8            	12112407	       99.22 ns/op	      21 B/op	       2 allocs/op
+BenchmarkLogger_MessageFormatting/standard_single-8         	 6090074	       197.7 ns/op	      24 B/op	       1 allocs/op
+
+BenchmarkLogger_MessageFormatting/clogs_double-8            	 9817215	       122.9 ns/op	      40 B/op	       2 allocs/op
+BenchmarkLogger_MessageFormatting/standard_double-8         	 4248105	       283.7 ns/op	      24 B/op	       1 allocs/op
+
+BenchmarkLogger_MessageFormatting/clogs_triple-8            	 8455057	       141.6 ns/op	      80 B/op	       2 allocs/op
+BenchmarkLogger_MessageFormatting/standard_triple-8         	 3386719	       354.6 ns/op	      24 B/op	       1 allocs/op
 ```
 
 ## Example Usage

--- a/clogs.go
+++ b/clogs.go
@@ -135,9 +135,21 @@ func (l *Logger) Println(v ...any) {
 	l.output("INF", v...)
 }
 
+// Printf writes a log message at the "INF" level.
+// Arguments are handled in the manner of [log.Printf].
+func (l *Logger) Printf(format string, v ...any) {
+	l.output("INF", fmt.Sprintf(format, v...))
+}
+
 // Println writes a log message at the "INF" level.
 func Println(v ...any) {
 	std.Println(v...)
+}
+
+// Printf writes a log message at the "INF" level.
+// Arguments are handled in the manner of [log.Printf].
+func Printf(format string, v ...any) {
+	std.Printf(format, v...)
 }
 
 // Debugln writes a log message at the "DBG" level.
@@ -147,6 +159,12 @@ func (l *Logger) Debugln(v ...any) {
 	}
 }
 
+// Debugf writes a log message at the "DBG" level.
+// Arguments are handled in the manner of [log.Printf].
+func (l *Logger) Debugf(format string, v ...any) {
+	l.output("DBG", fmt.Sprintf(format, v...))
+}
+
 // Debugln writes a log message at the "DBG" level.
 func Debugln(v ...any) {
 	if std.debugMode {
@@ -154,9 +172,21 @@ func Debugln(v ...any) {
 	}
 }
 
+// Debugf writes a log message at the "DBG" level.
+// Arguments are handled in the manner of [log.Printf].
+func Debugf(format string, v ...any) {
+	std.Debugf(format, v...)
+}
+
 // Infoln writes a log message at the "INF" level.
 func (l *Logger) Infoln(v ...any) {
 	l.output("INF", v...)
+}
+
+// Infof writes a log message at the "INF" level.
+// Arguments are handled in the manner of [log.Printf].
+func (l *Logger) Infof(format string, v ...any) {
+	l.output("INF", fmt.Sprintf(format, v...))
 }
 
 // Infoln writes a log message at the "INF" level.
@@ -164,9 +194,21 @@ func Infoln(v ...any) {
 	std.Infoln(v...)
 }
 
+// Infof writes a log message at the "INF" level.
+// Arguments are handled in the manner of [log.Printf].
+func Infof(format string, v ...any) {
+	std.Infof(format, v...)
+}
+
 // Warnln writes a log message at the "WRN" level.
 func (l *Logger) Warnln(v ...any) {
 	l.output("WRN", v...)
+}
+
+// Warnf writes a log message at the "WRN" level.
+// Arguments are handled in the manner of [log.Printf].
+func (l *Logger) Warnf(format string, v ...any) {
+	l.output("WRN", fmt.Sprintf(format, v...))
 }
 
 // Warnln writes a log message at the "WRN" level.
@@ -174,12 +216,30 @@ func Warnln(v ...any) {
 	std.Warnln(v...)
 }
 
+// Warnf writes a log message at the "WRN" level.
+// Arguments are handled in the manner of [log.Printf].
+func Warnf(format string, v ...any) {
+	std.Warnf(format, v...)
+}
+
 // Errorln writes a log message at the "ERR" level.
 func (l *Logger) Errorln(v ...any) {
 	l.output("ERR", v...)
 }
 
+// Errorf writes a log message at the "ERR" level.
+// Arguments are handled in the manner of [log.Printf].
+func (l *Logger) Errorf(format string, v ...any) {
+	l.output("ERR", fmt.Sprintf(format, v...))
+}
+
 // Errorln writes a log message at the "ERR" level.
 func Errorln(v ...any) {
 	std.Errorln(v...)
+}
+
+// Errorf writes a log message at the "ERR" level.
+// Arguments are handled in the manner of [log.Printf].
+func Errorf(format string, v ...any) {
+	std.Errorf(format, v...)
 }

--- a/clogs_test.go
+++ b/clogs_test.go
@@ -68,7 +68,7 @@ func TestLogger_Println(t *testing.T) {
 	}
 }
 
-func TestLogger_OutputFormat(t *testing.T) {
+func TestLogger_Println_OutputFormat(t *testing.T) {
 	var buf bytes.Buffer
 	logger := clogs.New(&buf)
 
@@ -94,6 +94,35 @@ func TestLogger_OutputFormat(t *testing.T) {
 	// Check log level and message
 	if !strings.HasPrefix(parts[2], "INF test message") {
 		t.Errorf("Expected message to start with 'INF test message', got: %s", parts[2])
+	}
+}
+
+func TestLogger_Printf_OutputFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger := clogs.New(&buf)
+
+	logger.Printf("digit: %d, value: %v", 123, "abc")
+	output := buf.String()
+
+	// Should have format: "YYYY-MM-DD HH:MM:SS INF digit: 123, value: abc\n"
+	parts := strings.SplitN(output, " ", 3)
+	if len(parts) != 3 {
+		t.Fatalf("Expected 3 parts (date, time, rest), got %d: %v", len(parts), parts)
+	}
+
+	// Check date format (YYYY-MM-DD)
+	if len(parts[0]) != 10 || parts[0][4] != '-' || parts[0][7] != '-' {
+		t.Errorf("Expected date format YYYY-MM-DD, got: %s", parts[0])
+	}
+
+	// Check time format (HH:MM:SS)
+	if len(parts[1]) != 8 || parts[1][2] != ':' || parts[1][5] != ':' {
+		t.Errorf("Expected time format HH:MM:SS, got: %s", parts[1])
+	}
+
+	// Check log level and message
+	if !strings.HasPrefix(parts[2], "INF digit: 123, value: abc") {
+		t.Errorf("Expected message to start with 'INF digit: 123, value: abc', got: %s", parts[2])
 	}
 }
 


### PR DESCRIPTION
This change adds the following methods for formatting log messages:

- `Printf`
- `Debugf`
- `Infof`
- `Warnf`
- `Errorf`

Arguments are handled in the manner of `log.Printf`: the string is formatted according to the specifier + provided arguments, then returned with a trailing newline.

Use of `Println`/etc. is still preferred, as `clogs` merely bails out to `fmt.Sprintf` for formatting. It is still slightly more performant than the standard logger, but it commonly requires more allocations per log operation.